### PR TITLE
Removing unused appName

### DIFF
--- a/train_mmlspark.py
+++ b/train_mmlspark.py
@@ -33,7 +33,7 @@ def plot_roc(true_y,predict_y):
 run_logger = get_azureml_logger() 
 
 # Start Spark application
-spark = pyspark.sql.SparkSession.builder.appName("Adult Census Income").getOrCreate()
+spark = pyspark.sql.SparkSession.getOrCreate()
 
 # Download AdultCensusIncome.csv from Azure CDN. This file has 32,561 rows.
 dataFile = "AdultCensusIncome.csv"


### PR DESCRIPTION
Setting appName("Adult Census Income") on the Spark Context may not work here as expected. The spark context is not started here, and so any settings on the sparkcontext will not take effect. Adding this setting here can be confusing and lead to the user trying to set other settings here. All settings must be done in the spark_dependencies.yml